### PR TITLE
feat: add "rounds" possibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,23 @@ $ npm install crypt3-passwd
 ## Usage
 #### encrypt(password: String, salt: String, algo: String)
   - password (required)
-  - salt (optional): if missing, will auto create random salt
+  - salt (optional): if missing, will auto create random salt (length=16) without rounds part
   - algo (optional): 'md5'|'sha256'|'sha512'(default)
 #### verify(password: String, hashed: String)
 
 ```js
 const crypt3 = require('crypt3-passwd')
 
-crypt3.encrypt('jimmy', 'salt', 'sha512') // '$6$salt$n6uyPG4ghvr5KGSCwnvMIoR7415LScAxExYuSwntPu3nzYunXfOyoxGjztZipEmt72wJaBwALWuV24MscmUBe1'
-crypt3.verify('jimmy', '$6$salt$n6uyPG4ghvr5KGSCwnvMIoR7415LScAxExYuSwntPu3nzYunXfOyoxGjztZipEmt72wJaBwALWuV24MscmUBe1') // true
+crypt3.verify(
+  'jimmy',
+  crypt3.encrypt('jimmy', 'salt', 'sha512')
+) 
+
+// user-supplied hashing rounds support as well
+crypt3.verify(
+  'jimmy',
+  crypt3.encrypt('jimmy', 'rounds=1000$salt')
+)
+// rounds number should be between `1000` and `999999999`
+// see: https://man7.org/linux/man-pages/man3/crypt.3.html for more details
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const bindings = require('node-gyp-build')(__dirname)
-bindings.verify = (passwd, hash, algo) => hash === bindings.encrypt(passwd, hash.split('$')[2], algo)
+bindings.verify = (passwd, hash, algo) => hash === bindings.encrypt(passwd, hash.match(/\d\$(.+)\$/)[1], algo)
 
 const ENUM_ALGO = {
   '1': 'md5',

--- a/test/crypt3.test.js
+++ b/test/crypt3.test.js
@@ -20,7 +20,8 @@ const data = {
     salt: 'salt/SHA512',
     algo: 'sha512',
     passwd: 'jimmy',
-    hashed: '$6$salt/SHA512$dfLSBj9voHuXzHhCmaaZvQmaIZ9f7UsOJUsoq4t3mOqKgz4ls.vKb9k6QvNND2Vwb86R1PV3rKmwBHIg4HtQj/'
+    hashed: '$6$salt/SHA512$dfLSBj9voHuXzHhCmaaZvQmaIZ9f7UsOJUsoq4t3mOqKgz4ls.vKb9k6QvNND2Vwb86R1PV3rKmwBHIg4HtQj/',
+    roundedHashed: '$6$rounds=5000$salt/SHA512$dfLSBj9voHuXzHhCmaaZvQmaIZ9f7UsOJUsoq4t3mOqKgz4ls.vKb9k6QvNND2Vwb86R1PV3rKmwBHIg4HtQj/'
   },
   'sha256': {
     openssl: 'openssl passwd -5 -salt salt/SHA256 jimmy',
@@ -45,6 +46,13 @@ test('Encryption', (batch) => {
     t.plan(1)
     const hashedPassword = encrypt(password, 'salt/SHA512', 'sha512')
     t.ok(hashedPassword === data['sha512'].hashed)
+  })
+
+  batch.test('sha512 with round=5000', (t) => {
+    t.plan(1)
+    const hashedPassword = encrypt(password, 'rounds=5000$salt/SHA512', 'sha512')
+    console.log(hashedPassword)
+    t.ok(hashedPassword === data['sha512'].roundedHashed)
   })
 
   batch.test('sha256', (t) => {


### PR DESCRIPTION
a slight modification of the salt extraction to allow verification of hashes of the form $id$rounds=yyy$salt$encrypted, as documented in the crypt(3) man page.
the encrypt method is fine as you can call it as :
`crypt.encrypt('pass','rounds=99999$'+crypt.createSalt())`
and it works